### PR TITLE
made datepicker layout mobile responsive

### DIFF
--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/gui/views/MealPlan.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/gui/views/MealPlan.java
@@ -122,14 +122,14 @@ public class MealPlan extends VerticalLayout implements BeforeEnterObserver {
         mensaComboBox.setWidth(60f, Unit.PERCENTAGE);
         mensaComboBox.setMinWidth(320f, Unit.PIXELS);
         datePicker.setWidth(40f, Unit.PERCENTAGE);
-        datePicker.setMinWidth(320f, Unit.PIXELS);
+        datePicker.setMinWidth(220, Unit.PIXELS);
 
         VerticalLayout headerContent = new VerticalLayout();
         headerContent.setWidth(100f, Unit.PERCENTAGE);
         headerContent.setAlignItems(Alignment.CENTER);
         headerContent.setJustifyContentMode(JustifyContentMode.CENTER);
         headerContent.getStyle().set("text-align", "center");
-        headerContent.add(new H2("Wähle deine Mensa aus, sowie das gewünschte Datum"));
+        headerContent.add(new H2("MensaHub-Speiseplan"));
         headerContent.add(headerComboboxDatePickerButtonsLayout);
 
         pageSelHeader.add(headerContent);


### PR DESCRIPTION
Das halte Layout war für mobile Geräte zu groß skaliert. Habe die min Width angepasst und dabei gleich die Überschrift geändert