### PR TITLE
157 push notifications

### DIFF
--- a/MensaHub-Collaborative-Filtering-API-Adapter/pom.xml
+++ b/MensaHub-Collaborative-Filtering-API-Adapter/pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>de.olech2412.mensahub</groupId>
             <artifactId>mensahub-models</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/MensaHub-DataDispatcher/pom.xml
+++ b/MensaHub-DataDispatcher/pom.xml
@@ -36,7 +36,12 @@
         <dependency>
             <groupId>de.olech2412.mensahub</groupId>
             <artifactId>mensahub-models</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
+        </dependency>
+        <dependency>
+            <groupId>de.olech2412.mensahub</groupId>
+            <artifactId>mensahub-collaborative-filtering-api-adapter</artifactId>
+            <version>1.0.3</version>
         </dependency>
         <!-- MensaHub-Dependencies End -->
 

--- a/MensaHub-DataDispatcher/src/main/java/de/olech2412/mensahub/datadispatcher/MensaHub_DataDispatcher.java
+++ b/MensaHub-DataDispatcher/src/main/java/de/olech2412/mensahub/datadispatcher/MensaHub_DataDispatcher.java
@@ -33,7 +33,7 @@ public class MensaHub_DataDispatcher {
         ConfigurableApplicationContext configurableApplicationContext = SpringApplication.run(MensaHub_DataDispatcher.class, args);
         LeipzigDataDispatcher leipzigDataDispatcher = configurableApplicationContext.getBean(LeipzigDataDispatcher.class);
 
-        leipzigDataDispatcher.callData();
+        leipzigDataDispatcher.sendEmails();
 
         if (Arrays.stream(args).toList().contains("sendMailManual")) {
             log.info("Sending emails manually");

--- a/MensaHub-Gateway/pom.xml
+++ b/MensaHub-Gateway/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>de.olech2412.mensahub</groupId>
             <artifactId>mensahub-models</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
         </dependency>
         <!-- MensaHub-Dependencies End -->
 

--- a/MensaHub-Junction/pom.xml
+++ b/MensaHub-Junction/pom.xml
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>de.olech2412.mensahub</groupId>
             <artifactId>mensahub-models</artifactId>
-            <version>2.1.4</version>
+            <version>2.1.5</version>
         </dependency>
         <dependency>
             <groupId>de.olech2412.mensahub</groupId>
@@ -105,6 +105,10 @@
         <dependency>
             <groupId>com.vaadin</groupId>
             <artifactId>vaadin-spring-boot-starter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-webpush</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/MensaHub_Junction.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/MensaHub_Junction.java
@@ -64,5 +64,10 @@ public class MensaHub_Junction implements AppShellConfigurator {
 
         // configure mail settings
         System.setProperty("adminMail", Config.getInstance().getProperty("mensaHub.junction.mail.adminMail"));
+
+        // load credentials for push notifications
+        System.setProperty("push.private.key", Config.getInstance().getProperty("mensaHub.junction.push.notification.private.key"));
+        System.setProperty("push.public.key", Config.getInstance().getProperty("mensaHub.junction.push.notification.public.key"));
+        System.setProperty("push.subject", Config.getInstance().getProperty("mensaHub.junction.address"));
     }
 }

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/config/Config.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/config/Config.java
@@ -104,6 +104,9 @@ public class Config {
         propertiesToEncrypt.add("mensaHub.database.name");
         propertiesToEncrypt.add("mensaHub.database.username");
         propertiesToEncrypt.add("mensaHub.junction.mail.sender.password");
+        propertiesToEncrypt.add("mensaHub.junction.push.notification.api.key");
+        propertiesToEncrypt.add("mensaHub.junction.push.notification.private.key");
+        propertiesToEncrypt.add("mensaHub.junction.push.notification.public.key");
 
         for (String key : propertiesToEncrypt) {
             String property = getPropertyEncrypted(key);

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/gui/components/vaadin/dialogs/PushNotificationDialog.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/gui/components/vaadin/dialogs/PushNotificationDialog.java
@@ -1,0 +1,158 @@
+package de.olech2412.mensahub.junction.gui.components.vaadin.dialogs;
+
+import com.vaadin.flow.component.Text;
+import com.vaadin.flow.component.Unit;
+import com.vaadin.flow.component.button.Button;
+import com.vaadin.flow.component.dialog.Dialog;
+import com.vaadin.flow.component.html.Div;
+import com.vaadin.flow.component.html.Span;
+import com.vaadin.flow.component.html.UnorderedList;
+import com.vaadin.flow.component.html.ListItem;
+import com.vaadin.flow.component.orderedlayout.FlexComponent;
+import com.vaadin.flow.component.orderedlayout.HorizontalLayout;
+import com.vaadin.flow.server.webpush.WebPush;
+import com.vaadin.flow.server.webpush.WebPushMessage;
+import de.olech2412.mensahub.junction.gui.components.vaadin.layouts.generic.FooterButtonLayout;
+import com.vaadin.flow.component.icon.Icon;
+import com.vaadin.flow.component.icon.VaadinIcon;
+import de.olech2412.mensahub.junction.gui.components.vaadin.notifications.NotificationFactory;
+import de.olech2412.mensahub.junction.gui.components.vaadin.notifications.types.NotificationType;
+import de.olech2412.mensahub.junction.jpa.services.MailUserService;
+import de.olech2412.mensahub.junction.webpush.WebPushService;
+import de.olech2412.mensahub.models.authentification.MailUser;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class PushNotificationDialog extends Dialog {
+
+    private FooterButtonLayout footerButtonLayout = new FooterButtonLayout();
+
+    private WebPushService webPushService;
+
+    private MailUserService mailUserService;
+
+    public PushNotificationDialog(WebPushService webPushService, MailUserService mailUserService, MailUser mailUser) {
+        super("Push-Benachrichtigung");
+
+        this.webPushService = webPushService;
+        this.mailUserService = mailUserService;
+
+        // iOS & iPadOS Header
+        Icon warningIcon = new Icon(VaadinIcon.WARNING);
+        warningIcon.getStyle().set("color", "#ffcc00");
+        warningIcon.getStyle().set("margin-right", "10px");
+
+        Span iosTitle = new Span("iOS & iPadOS Support");
+        iosTitle.getStyle().set("font-weight", "bold");
+        iosTitle.getStyle().set("font-size", "16px");
+
+        Div iosHeader = new Div(warningIcon, iosTitle);
+        iosHeader.getStyle().set("display", "flex");
+        iosHeader.getStyle().set("align-items", "center");
+
+        // iOS & iPadOS Beschreibung und Liste
+        Span iosDescription = new Span("Mobile Web Push für iOS und iPadOS erfordert Folgendes:");
+
+        UnorderedList iosRequirementsList = new UnorderedList(
+                new ListItem("iOS- oder iPadOS-Version 16.4 oder höher;"),
+                new ListItem("Der Benutzer muss die Webanwendung über das Menü „Teilen“ in Safari zum Startbildschirm hinzufügen; und"),
+                new ListItem("Eine vom Benutzer generierte Aktion ist erforderlich, um die Berechtigungsaufforderung auf der zum Startbildschirm hinzugefügten Webanwendung zu aktivieren.")
+        );
+
+        Span iosAdditionalInfo = new Span("Für iOS und iPadOS muss die Registrierung in der installierten Webanwendung erfolgen. ");
+
+        Span safariInfo = new Span("Außerdem müssen in Safari die Web-Push-Benachrichtigungsfunktionen aktiviert sein. Gehe dazu zu ");
+        Span safariPath = new Span("Einstellungen → Safari → Erweitert → Experimentelle Funktionen.");
+        safariPath.getStyle().set("font-style", "italic");
+        safariInfo.add(safariPath);
+        Span enableNotifications = new Span(" Dort kannst du ");
+        Span notifications = new Span("Benachrichtigungen");
+        notifications.getStyle().set("background-color", "#e0e0e0").set("padding", "2px 4px").set("border-radius", "4px");
+        Span andText = new Span(" und ");
+        Span pushApi = new Span("Push-API");
+        pushApi.getStyle().set("background-color", "#e0e0e0").set("padding", "2px 4px").set("border-radius", "4px");
+        safariInfo.add(enableNotifications, notifications, andText, pushApi, new Text(" aktivieren."));
+
+        Div iosContent = new Div(iosHeader, iosDescription, iosRequirementsList, iosAdditionalInfo, safariInfo);
+        iosContent.getStyle().set("padding", "10px");
+        iosContent.getStyle().set("border", "1px solid #ffcc00");
+        iosContent.getStyle().set("border-radius", "8px");
+        iosContent.getStyle().set("background-color", "#fdfde8");
+        iosContent.getStyle().set("margin-bottom", "20px");
+
+        // Brave Browser Header
+        Span braveTitle = new Span("Brave Browser Support");
+        braveTitle.getStyle().set("font-weight", "bold");
+        braveTitle.getStyle().set("font-size", "16px");
+
+        Div braveHeader = new Div(warningIcon, braveTitle);
+        braveHeader.getStyle().set("display", "flex");
+        braveHeader.getStyle().set("align-items", "center");
+
+        // Brave Beschreibung
+        Span braveDescription = new Span("Für den Brave-Browser können Web-Push-Benachrichtigungen standardmäßig funktionieren, wenn der Browser erstmals installiert wird. Falls nicht, müssen Benachrichtigungen im Browser aktiviert werden. ");
+
+        Span braveAdditionalInfo = new Span("Der Benutzer sollte die Datenschutzeinstellungen des Browsers öffnen (z. B. ");
+        Span bravePath = new Span("brave://settings/privacy");
+        bravePath.getStyle().set("font-style", "italic");
+        braveAdditionalInfo.add(bravePath, new Text(") und die Option „Google-Dienste für Push-Nachrichten verwenden“ aktivieren."));
+
+        Div braveContent = new Div(braveHeader, braveDescription, braveAdditionalInfo);
+        braveContent.getStyle().set("padding", "10px");
+        braveContent.getStyle().set("border", "1px solid #ffcc00");
+        braveContent.getStyle().set("border-radius", "8px");
+        braveContent.getStyle().set("background-color", "#fdfde8");
+
+        footerButtonLayout.declineButton.addClickListener(buttonClickEvent -> this.close());
+        footerButtonLayout.acceptButton.setVisible(false);
+        footerButtonLayout.acceptButton.setWidth(0, Unit.PIXELS);
+        footerButtonLayout.declineButton.setWidth(100f, Unit.PERCENTAGE);
+
+        WebPush webpush = webPushService.getWebPush();
+
+        Button subscribe = new Button("Anmelden");
+        subscribe.setIcon(VaadinIcon.CHECK.create());
+        Button unsubscribe = new Button("Abmelden");
+        unsubscribe.setIcon(VaadinIcon.TRASH.create());
+
+        subscribe.setEnabled(!mailUser.isPushNotificationsEnabled());
+        subscribe.addClickListener(e -> {
+            webpush.subscribe(subscribe.getUI().get(), subscription -> {
+                webPushService.store(subscription);
+                subscribe.setEnabled(false);
+                unsubscribe.setEnabled(true);
+                mailUser.setPushNotificationsEnabled(true);
+                mailUser.setSubscription(mailUserService.convertToEntity(subscription));
+                mailUserService.saveMailUser(mailUser);
+                NotificationFactory.create(NotificationType.SUCCESS, "Push Notifications wurden abonniert. Überprüfe den Empfang der Testnachricht," +
+                        " wenn du diese nicht erhalten hast, überprüfe deine System-/Browsereinstellungen").open();
+                webpush.sendNotification(subscription, new WebPushMessage("MensaHub-Test", "Wenn du diese Nachricht empfangen kannst," +
+                        " wurden die Push Benachrichtigungen erfolgreich eingerichtet"));
+                log.info("User {} enabled push notifications", mailUser.getEmail());
+            });
+        });
+
+        unsubscribe.setEnabled(mailUser.isPushNotificationsEnabled());
+        unsubscribe.addClickListener(e -> {
+            webpush.unsubscribe(unsubscribe.getUI().get(), subscription -> {
+                webPushService.remove(subscription);
+                subscribe.setEnabled(true);
+                unsubscribe.setEnabled(false);
+                mailUser.setPushNotificationsEnabled(false);
+                mailUser.setSubscription(null);
+                mailUserService.saveMailUser(mailUser);
+                NotificationFactory.create(NotificationType.SUCCESS, "Push Notifications wurden für dich deaktiviert").open();
+                log.info("User {} disabled push notifications", mailUser.getEmail());
+            });
+        });
+
+        HorizontalLayout subscribeLayout = new HorizontalLayout(subscribe, unsubscribe);
+        subscribeLayout.setAlignItems(FlexComponent.Alignment.CENTER);
+        subscribeLayout.setSpacing(true);
+        subscribeLayout.setJustifyContentMode(FlexComponent.JustifyContentMode.CENTER);
+
+        add(iosContent, braveContent, subscribeLayout, footerButtonLayout);
+    }
+}

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/gui/views/MailSettingsView.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/gui/views/MailSettingsView.java
@@ -24,6 +24,7 @@ import de.olech2412.mensahub.junction.email.Mailer;
 import de.olech2412.mensahub.junction.gui.components.vaadin.datetimepicker.GermanDatePicker;
 import de.olech2412.mensahub.junction.gui.components.vaadin.dialogs.MailUserSetupDialog;
 import de.olech2412.mensahub.junction.gui.components.vaadin.dialogs.PreferencesDialog;
+import de.olech2412.mensahub.junction.gui.components.vaadin.dialogs.PushNotificationDialog;
 import de.olech2412.mensahub.junction.gui.components.vaadin.notifications.NotificationFactory;
 import de.olech2412.mensahub.junction.gui.components.vaadin.notifications.types.CookieNotification;
 import de.olech2412.mensahub.junction.gui.components.vaadin.notifications.types.NotificationType;
@@ -34,6 +35,7 @@ import de.olech2412.mensahub.junction.jpa.repository.mensen.MensaRepository;
 import de.olech2412.mensahub.junction.jpa.services.MailUserService;
 import de.olech2412.mensahub.junction.jpa.services.PreferencesService;
 import de.olech2412.mensahub.junction.jpa.services.meals.MealsService;
+import de.olech2412.mensahub.junction.webpush.WebPushService;
 import de.olech2412.mensahub.models.Mensa;
 import de.olech2412.mensahub.models.Preferences;
 import de.olech2412.mensahub.models.authentification.MailUser;
@@ -72,14 +74,17 @@ public class MailSettingsView extends Composite implements BeforeEnterObserver {
     @Autowired
     private PreferencesService preferencesService;
 
+    private WebPushService webPushService;
+
     public MailSettingsView(DeactivationCodeRepository deactivationCodeRepository, MailUserService mailUserService,
                             ActivationCodeRepository activationCodeRepository, MensaRepository mensaRepository,
-                            MealsService mealsService) {
+                            MealsService mealsService, WebPushService webPushService) {
         this.deactivationCodeRepository = deactivationCodeRepository;
         this.mailUserService = mailUserService;
         this.activationCodeRepository = activationCodeRepository;
         this.mensaRepository = mensaRepository;
         this.mealsService = mealsService;
+        this.webPushService = webPushService;
 
         new CookieNotification(); // check if cookies are already accepted or show the cookie banner
     }
@@ -201,7 +206,15 @@ public class MailSettingsView extends Composite implements BeforeEnterObserver {
             mailUserSetupDialog.open();
         });
 
-        FormLayout formLayout = new FormLayout(headlineDelete, explanationDelete, deactivate, deactivateForTime, mailUserSettings, preferences);
+        Button pushNotificationDialogButton = new Button("Push Benachrichtigungen");
+        pushNotificationDialogButton.addThemeVariants(ButtonVariant.LUMO_PRIMARY);
+        pushNotificationDialogButton.setIcon(VaadinIcon.BELL_O.create());
+        pushNotificationDialogButton.addClickListener(buttonClickEvent -> {
+            PushNotificationDialog pushNotificationDialog = new PushNotificationDialog(webPushService, mailUserService, mailUser);
+            pushNotificationDialog.open();
+        });
+
+        FormLayout formLayout = new FormLayout(headlineDelete, explanationDelete, deactivate, deactivateForTime, mailUserSettings, preferences, pushNotificationDialogButton);
 
         content.add(formLayout);
         layout.add(content);

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/jpa/services/MailUserService.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/jpa/services/MailUserService.java
@@ -5,6 +5,7 @@ import de.olech2412.mensahub.junction.jpa.repository.mensen.MensaRepository;
 import de.olech2412.mensahub.models.Mensa;
 import de.olech2412.mensahub.models.Rating;
 import de.olech2412.mensahub.models.authentification.MailUser;
+import de.olech2412.mensahub.models.authentification.SubscriptionEntity;
 import de.olech2412.mensahub.models.jobs.Job;
 import de.olech2412.mensahub.models.result.Result;
 import de.olech2412.mensahub.models.result.errors.Application;
@@ -12,6 +13,7 @@ import de.olech2412.mensahub.models.result.errors.ErrorEntity;
 import de.olech2412.mensahub.models.result.errors.jpa.JPAError;
 import de.olech2412.mensahub.models.result.errors.jpa.JPAErrors;
 import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Subscription;
 import org.hibernate.Hibernate;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -113,5 +115,19 @@ public class MailUserService {
             ratingRepository.save(rating);
         }
         mailUserRepository.delete(mailUser);
+    }
+
+    public SubscriptionEntity convertToEntity(Subscription subscription) {
+        return new SubscriptionEntity(
+                subscription.endpoint(),
+                new SubscriptionEntity.KeysEntity(subscription.keys().p256dh(), subscription.keys().auth())
+        );
+    }
+
+    public Subscription convertToModel(SubscriptionEntity entity) {
+        return new Subscription(
+                entity.getEndpoint(),
+                new Subscription.Keys(entity.getKeys().getP256dh(), entity.getKeys().getAuth())
+        );
     }
 }

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/security/SecurityConfig.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/security/SecurityConfig.java
@@ -1,12 +1,17 @@
 package de.olech2412.mensahub.junction.security;
 
 import com.vaadin.flow.spring.security.VaadinWebSecurity;
+import de.olech2412.mensahub.junction.config.Config;
 import de.olech2412.mensahub.junction.gui.views.LoginView;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 import javax.sql.DataSource;
@@ -20,12 +25,13 @@ public class SecurityConfig extends VaadinWebSecurity {
 
     @Autowired
     public void configAuthentication(AuthenticationManagerBuilder auth) throws Exception {
-        auth.jdbcAuthentication().passwordEncoder(new BCryptPasswordEncoder())
+        // Authentifizierung für die Benutzer der Webanwendung (aus Datenbank)
+        auth.jdbcAuthentication().passwordEncoder(passwordEncoder())
                 .dataSource(dataSource)
                 .usersByUsernameQuery("select username, password, verified_email from api_user where username=?")
                 .authoritiesByUsernameQuery("select username, role from api_user where username=?");
 
-        auth.jdbcAuthentication().passwordEncoder(new BCryptPasswordEncoder())
+        auth.jdbcAuthentication().passwordEncoder(passwordEncoder())
                 .dataSource(dataSource)
                 .usersByUsernameQuery("select username, password, enabled from users where username=?")
                 .authoritiesByUsernameQuery("select username, role from users where username=?");
@@ -43,5 +49,15 @@ public class SecurityConfig extends VaadinWebSecurity {
         super.configure(http);
 
         setLoginView(http, LoginView.class);
+    }
+
+    @Override
+    public void configure(WebSecurity web) throws Exception {
+        web.ignoring().requestMatchers("/api/**");
+        super.configure(web);
+    }
+
+    private BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
     }
 }

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/webpush/WebPushService.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/webpush/WebPushService.java
@@ -1,0 +1,78 @@
+package de.olech2412.mensahub.junction.webpush;
+
+import lombok.extern.slf4j.Slf4j;
+import nl.martijndwars.webpush.Subscription;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.security.GeneralSecurityException;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.vaadin.flow.server.webpush.WebPush;
+import com.vaadin.flow.server.webpush.WebPushMessage;
+
+@Service
+@Slf4j
+public class WebPushService {
+
+    @Value("${push.public.key}") // env variables loaded in Spring init class from config
+    private String publicKey;
+    @Value("${push.private.key}")
+    private String privateKey;
+    @Value("${push.subject}")
+    private String subject;
+
+    private final Map<String, Subscription> endpointToSubscription = new HashMap<>();
+
+    WebPush webPush;
+
+    /**
+     * Initialize security and push service for initial get request.
+     *
+     * @throws GeneralSecurityException security exception for security complications
+     */
+    public WebPush getWebPush() {
+        if(webPush == null) {
+            webPush = new WebPush(publicKey, privateKey, subject);
+        }
+        return webPush;
+    }
+
+    /**
+     * Send a notification to all subscriptions.
+     *
+     * @param title message title
+     * @param body message body
+     */
+    public void notifyAll(String title, String body) {
+        endpointToSubscription.values().forEach(subscription -> {
+            webPush.sendNotification(subscription, new WebPushMessage(title, body));
+        });
+    }
+
+    public void store(Subscription subscription) {
+        log.info("Subscribed to {}", subscription.endpoint());
+        /*
+         * Note, in a real world app you'll want to persist these
+         * in the backend. Also, you probably want to know which
+         * subscription belongs to which user to send custom messages
+         * for different users. In this demo, we'll just use
+         * endpoint URL as key to store subscriptions in memory.
+         */
+        endpointToSubscription.put(subscription.endpoint(), subscription);
+    }
+
+
+    public void remove(Subscription subscription) {
+        log.info("Unsubscribed from {}", subscription.endpoint());
+        endpointToSubscription.remove(subscription.endpoint());
+    }
+
+    public boolean isEmpty() {
+        return endpointToSubscription.isEmpty();
+    }
+
+}

--- a/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/webpush/WebPushTriggerEndpoint.java
+++ b/MensaHub-Junction/src/main/java/de/olech2412/mensahub/junction/webpush/WebPushTriggerEndpoint.java
@@ -1,0 +1,66 @@
+package de.olech2412.mensahub.junction.webpush;
+
+import com.vaadin.flow.server.webpush.WebPushMessage;
+import de.olech2412.mensahub.junction.config.Config;
+import de.olech2412.mensahub.junction.jpa.services.MailUserService;
+import de.olech2412.mensahub.models.authentification.MailUser;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/webpush")
+@Slf4j
+public class WebPushTriggerEndpoint {
+
+    @Autowired
+    private WebPushService webPushService;
+
+    @Autowired
+    private MailUserService mailUserService;
+
+    @PostMapping("/send")
+    public ResponseEntity<String> sendPushNotification(@RequestParam String message,
+                                                       @RequestParam String title,
+                                                       @RequestParam String mailAdress,
+                                                       @RequestParam String apiKey) {
+        try {
+            MailUser mailUser;
+
+            if(!Config.getInstance().getProperty("mensaHub.junction.push.notification.api.key").equals(apiKey)){
+                return new ResponseEntity<>(HttpStatus.UNAUTHORIZED);
+            }
+
+
+                if (mailUserService.findMailUserByEmail(mailAdress).isEmpty()) {
+                    log.error("Cannot find mail adress: {}", mailAdress);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Cannot find mailAdress");
+            }
+
+            mailUser = mailUserService.findMailUserByEmail(mailAdress).get(0);
+
+            if (!mailUser.isPushNotificationsEnabled()) {
+                log.error("Mail notifications are disabled for user {}", mailAdress);
+                return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Mail notifications are disabled for this user");
+            }
+
+            if (mailUser.getSubscription() == null) {
+                log.error("Subscription is null for user {}", mailAdress);
+                return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("No subscription found for this user");
+            }
+
+            webPushService.webPush.sendNotification(mailUserService.convertToModel(mailUser.getSubscription()),
+                    new WebPushMessage(title, message));
+            log.info("WebPush notification sent to user {} with title {} and message {}", mailAdress, title, message);
+            return ResponseEntity.ok("Push notification sent successfully");
+        } catch (Exception e) {
+            log.error("Error while sending web push notification", e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).body("Failed to send push notification");
+        }
+    }
+}

--- a/MensaHub-Models/pom.xml
+++ b/MensaHub-Models/pom.xml
@@ -20,7 +20,7 @@
             <url>https://github.com/olech2412</url>
         </developer>
     </developers>
-    <version>2.1.4</version>
+    <version>2.1.5</version>
 
 
     <properties>

--- a/MensaHub-Models/src/main/java/de/olech2412/mensahub/models/authentification/MailUser.java
+++ b/MensaHub-Models/src/main/java/de/olech2412/mensahub/models/authentification/MailUser.java
@@ -45,6 +45,9 @@ public class MailUser {
     private boolean wantsCollaborationInfoMail; // if the user wants to get mails about collaborations only
     @OneToOne(cascade = CascadeType.ALL)
     private Preferences preferences;
+    private boolean pushNotificationsEnabled; // user wants push notifications?
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    private SubscriptionEntity subscription;
 
     /**
      * Default constructor for the mail-user.

--- a/MensaHub-Models/src/main/java/de/olech2412/mensahub/models/authentification/SubscriptionEntity.java
+++ b/MensaHub-Models/src/main/java/de/olech2412/mensahub/models/authentification/SubscriptionEntity.java
@@ -1,9 +1,13 @@
 package de.olech2412.mensahub.models.authentification;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.Setter;
 
 @Entity
 @Table(name = "subscriptions")
+@Getter
+@Setter
 public class SubscriptionEntity {
     
     @Id
@@ -24,19 +28,10 @@ public class SubscriptionEntity {
         this.keys = keys;
     }
 
-    public Long getId() {
-        return id;
-    }
-
-    public String getEndpoint() {
-        return endpoint;
-    }
-
-    public KeysEntity getKeys() {
-        return keys;
-    }
 
     @Embeddable
+    @Getter
+    @Setter
     public static class KeysEntity {
 
         @Column(name = "p256dh", nullable = false)
@@ -51,14 +46,6 @@ public class SubscriptionEntity {
         public KeysEntity(String p256dh, String auth) {
             this.p256dh = p256dh;
             this.auth = auth;
-        }
-
-        public String getP256dh() {
-            return p256dh;
-        }
-
-        public String getAuth() {
-            return auth;
         }
     }
 }

--- a/MensaHub-Models/src/main/java/de/olech2412/mensahub/models/authentification/SubscriptionEntity.java
+++ b/MensaHub-Models/src/main/java/de/olech2412/mensahub/models/authentification/SubscriptionEntity.java
@@ -1,0 +1,64 @@
+package de.olech2412.mensahub.models.authentification;
+
+import jakarta.persistence.*;
+
+@Entity
+@Table(name = "subscriptions")
+public class SubscriptionEntity {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Long id;
+
+    @Column(name = "endpoint", nullable = false)
+    private String endpoint;
+
+    @Embedded
+    private KeysEntity keys;
+
+    public SubscriptionEntity() {
+    }
+
+    public SubscriptionEntity(String endpoint, KeysEntity keys) {
+        this.endpoint = endpoint;
+        this.keys = keys;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getEndpoint() {
+        return endpoint;
+    }
+
+    public KeysEntity getKeys() {
+        return keys;
+    }
+
+    @Embeddable
+    public static class KeysEntity {
+
+        @Column(name = "p256dh", nullable = false)
+        private String p256dh;
+
+        @Column(name = "auth", nullable = false)
+        private String auth;
+
+        public KeysEntity() {
+        }
+
+        public KeysEntity(String p256dh, String auth) {
+            this.p256dh = p256dh;
+            this.auth = auth;
+        }
+
+        public String getP256dh() {
+            return p256dh;
+        }
+
+        public String getAuth() {
+            return auth;
+        }
+    }
+}


### PR DESCRIPTION
Muss das Prod richtig testen. Aktuell schlägt das versenden nach einem neustart der anwendung immer fehl, das kann aber prod komplett anders sein.

Funktionen:
- Nutzer kann in den Newsletter Einstellungen Push Notifications abbonieren
- Junction hat eine Rest Schnittstelle die mit einem key genutzt werden kann, damit der datadispatcher erkannte änderungen bzw. reguläre updates über push triggern kann
- neue models version, in der die push notifications abgespeichert werden können
- DataDispatcher prüft, ob der Mailuser die push notifications will, wenn ja triggered er diese bei updates und dem regulären versand. Wenn möglich werden Empfehlungen eingebaut
- Neue Config Parameter